### PR TITLE
曲リストにない楽曲（CS限定曲など）を別で出力する機能の提案

### DIFF
--- a/Core/SongSorterCore.cs
+++ b/Core/SongSorterCore.cs
@@ -11,9 +11,11 @@ public sealed record SongSortRunResult(
     int TotalCopied,
     int TotalSkipped,
     int TotalUnmatched,
-    string ReportPath)
+    string ReportPath,
+    int TotalEsePreserved = 0)
 {
-    public string Summary => $"整理完了: コピー {TotalCopied} / スキップ {TotalSkipped}";
+    public string Summary =>
+        $"整理完了: コピー {TotalCopied} / スキップ {TotalSkipped} / AC未収録曲 {TotalEsePreserved}";
 }
 
 public sealed record SongSortReportRow(
@@ -52,7 +54,9 @@ public static class SongSorterCore
         IReadOnlyCollection<string>? selectedSourceCategories,
         Action<string>? logAction = null,
         CancellationToken ct = default,
-        Action<SongSortProgress>? progressAction = null)
+        Action<SongSortProgress>? progressAction = null,
+        bool preserveEseSongs = true,
+        IReadOnlyCollection<string>? preserveEseCategories = null)
     {
         var appDataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SongConverter");
         var exportDir = Path.Combine(appDataDir, "Export");
@@ -102,6 +106,8 @@ public static class SongSorterCore
 
         var exportGroups = LoadExportIndexes(exportDir);
         var reportRows = new ConcurrentBag<SongSortReportRow>();
+        // 公式リストに一致しなかったESE限定曲を保持する別枠バッファ（並列走査中に詰める）
+        var esePreserved = new ConcurrentBag<EsePreservedSong>();
         var parallelOptions = new ParallelOptions
         {
             MaxDegreeOfParallelism = Math.Max(2, Math.Min(Environment.ProcessorCount * 2, 16)),
@@ -345,7 +351,10 @@ public static class SongSorterCore
                 }
                 else
                 {
-                    Interlocked.Increment(ref totalUnmatched);
+                    // 公式曲リストに一致しなかった曲
+                    // 従来はここで破棄していたが、破棄せず別枠（99 AC未収録曲）として保持する。
+                    // 実際のコピーと採番は、全カテゴリ走査後にカテゴリ単位でソートしてから
+                    // ProcessEsePreservedSongs で行う（フェーズ2）。
                     var reason = !titleMatched
                         ? "TitleNotFoundInExport"
                         : !subtitleMatched
@@ -353,7 +362,18 @@ public static class SongSorterCore
                             : !indexResolved
                                 ? "IndexNotResolved"
                                 : "Unknown";
-                    reportRows.Add(new SongSortReportRow(sourceMap.Category, songDir, "Unmatched", reason, reportTitle, reportSubtitle, matchedCategory, matchedKey));
+
+                    // candidates はこの時点で必ず1件以上（空なら前段でreturn済み）
+                    var primary = candidates[0];
+                    esePreserved.Add(new EsePreservedSong(
+                        EseCategory: sourceMap.Category,
+                        SongDir: songDir,
+                        TjaPath: primary.Path,
+                        Wave: primary.Info.Wave,
+                        Title: primary.Info.Title,
+                        Subtitle: primary.Info.Subtitle,
+                        SortKey: primary.TitleNorm,
+                        Reason: reason));
                 }
 
                 var p2 = Interlocked.Increment(ref processedFolders);
@@ -361,13 +381,160 @@ public static class SongSorterCore
             });
         }
 
+        // フェーズ2: アーケード未収録曲をAC側カテゴリごとにソートして別枠出力する。
+        // preserveEseCategories が null → 全カテゴリ出力（preserveEseSongs=trueと同義）。
+        // preserveEseCategories が空セット → 全スキップ（preserveEseSongs=falseと同義）。
+        // preserveEseCategories に値あり → そのカテゴリのみ出力。
+        int totalEsePreserved = 0;
+        var effectiveEseCategories = preserveEseCategories != null && preserveEseCategories.Count > 0
+            ? new HashSet<string>(preserveEseCategories, StringComparer.OrdinalIgnoreCase)
+            : (preserveEseSongs ? null : new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+        if (effectiveEseCategories == null || effectiveEseCategories.Count > 0)
+        {
+            var eseGenreMeta = mappings.ToDictionary(
+                m => m.Category,
+                m => (m.BoxTitle, m.BoxGenre, m.BoxExplanation),
+                StringComparer.Ordinal);
+            totalEsePreserved = ProcessEsePreservedSongs(songsRoot, esePreserved, eseGenreMeta, copyPathClaims, reportRows, ct, effectiveEseCategories);
+        }
+
         var reportPath = WriteReportCsv(exportDir, runId, reportRows);
-        return new SongSortRunResult(totalCopied, totalSkipped, totalUnmatched, reportPath);
+        return new SongSortRunResult(totalCopied, totalSkipped, totalUnmatched, reportPath, totalEsePreserved);
     }
 
     private static string ResolveSongsRoot(string selectedFolder)
     {
         return selectedFolder;
+    }
+
+    private const string EseRootFolderName = "99 AC未収録曲";
+    private const string EseRootBoxTitle = "AC未収録曲";
+    private const string EseRootGenre = "ESE";
+    private const string EseRootExplanation = "アーケード版にない曲をあつめたよ!";
+    private const string EseChildTitlePrefix = "【E】 ";
+    private const string EseChildExplanationPrefix = "AC版にない";
+
+    /// <summary>
+    /// 公式リストに一致しなかった曲（＝アーケード版未収録のESE限定曲）を、AC側カテゴリごとに
+    /// 分類・ソートし、「99 AC未収録曲」配下へ別枠出力する。
+    /// 「99 AC未収録曲」直下に各カテゴリのサブフォルダを作り、それぞれにbox.defを置く
+    /// 入れ子構成とする。カテゴリ別box.defの #GENRE・色はAC側と揃え、#TITLE に【E】、
+    /// #EXPLANATION に「AC版にない」を付与する。
+    /// 再実行時の冪等性を担保するため、別枠ツリーは毎回まるごと作り直す。
+    /// </summary>
+    /// <param name="genreMeta">AC側カテゴリ名 → (BoxTitle, BoxGenre, BoxExplanation) の対応表。</param>
+    /// <returns>別枠としてコピーした曲数。</returns>
+    private static int ProcessEsePreservedSongs(
+        string songsRoot,
+        ConcurrentBag<EsePreservedSong> songs,
+        IReadOnlyDictionary<string, (string BoxTitle, string BoxGenre, string BoxExplanation)> genreMeta,
+        ConcurrentDictionary<string, byte> copyPathClaims,
+        ConcurrentBag<SongSortReportRow> reportRows,
+        CancellationToken ct,
+        HashSet<string>? allowedCategories = null)
+    {
+        var eseRoot = Path.Combine(songsRoot, EseRootFolderName);
+
+        if (Directory.Exists(eseRoot))
+        {
+            try { Directory.Delete(eseRoot, recursive: true); }
+            catch { /* 削除に失敗しても処理を続行 */ }
+        }
+
+        // allowedCategories が null → 全カテゴリ出力。空セット → スキップ（呼び出し元でガード済み）。
+        var list = allowedCategories == null
+            ? songs.ToList()
+            : songs.Where(s => allowedCategories.Contains(s.EseCategory)).ToList();
+        if (list.Count == 0) return 0;
+
+        // 親フォルダのbox.def（99 AC未収録曲）。色は指定しない。
+        EnsureBoxDef(eseRoot, EseRootBoxTitle, EseRootGenre, EseRootExplanation, bgColor: null, textColor: null);
+
+        var copied = 0;
+
+        // AC側カテゴリ（採番済みの表示名）ごとに分類
+        var groups = list
+            .GroupBy(
+                s => string.IsNullOrWhiteSpace(s.EseCategory) ? "99 その他" : s.EseCategory,
+                StringComparer.Ordinal)
+            .OrderBy(g => g.Key, StringComparer.Ordinal);
+
+        foreach (var group in groups)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var genreName = group.Key;
+            var genreDir = Path.Combine(eseRoot, SanitizeFolderName(genreName));
+
+            // カテゴリ別box.defは対応するAC側の #GENRE・色をそのまま流用し、
+            // #TITLE に【E】、#EXPLANATION に「AC版にない」を付与する。
+            // 例: 【E】 ナムコオリジナル / AC版にないナムコオリジナルの曲をあつめたよ!
+            string childTitle, childGenre, childExplanation;
+            if (genreMeta.TryGetValue(genreName, out var meta))
+            {
+                childTitle = EseChildTitlePrefix + meta.BoxTitle;
+                childGenre = meta.BoxGenre;
+                childExplanation = EseChildExplanationPrefix + meta.BoxExplanation;
+            }
+            else
+            {
+                // 対応するAC側カテゴリが無い場合のフォールバック（通常は到達しない）。
+                childTitle = EseChildTitlePrefix + genreName;
+                childGenre = genreName;
+                childExplanation = EseChildExplanationPrefix + genreName + "の曲をあつめたよ!";
+            }
+            EnsureBoxDef(genreDir, childTitle, childGenre, childExplanation);
+
+            var ordered = group
+                .OrderBy(s => s.SortKey, StringComparer.Ordinal)
+                .ThenBy(s => s.Title, StringComparer.Ordinal)
+                .ThenBy(s => s.SongDir, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var index = 1;
+            foreach (var song in ordered)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var num = index.ToString("000");
+                var folderNameCandidates =
+                    BuildFolderNameCandidates(num, song.Title, song.Subtitle, song.TjaPath);
+
+                string? dstSongDir = null;
+                foreach (var folderName in folderNameCandidates)
+                {
+                    var candidatePath = Path.Combine(genreDir, folderName);
+                    if (!copyPathClaims.TryAdd(candidatePath, 0)) continue;
+                    if (Directory.Exists(candidatePath)) continue;
+                    dstSongDir = candidatePath;
+                    break;
+                }
+
+                if (dstSongDir == null)
+                {
+                    reportRows.Add(new SongSortReportRow(
+                        song.EseCategory, song.SongDir, "EsePreservedSkipped", "FolderClaimFailed",
+                        song.Title, song.Subtitle, $"{EseRootFolderName}/{genreName}", song.SortKey));
+                    continue;
+                }
+
+                CopyDirectory(song.SongDir, dstSongDir, song.TjaPath, song.Wave);
+                copied++;
+                index++;
+
+                reportRows.Add(new SongSortReportRow(
+                    song.EseCategory,
+                    song.SongDir,
+                    "EsePreserved",
+                    song.Reason,
+                    song.Title,
+                    song.Subtitle,
+                    $"{EseRootFolderName}/{genreName}",
+                    Path.GetFileName(dstSongDir)));
+            }
+        }
+
+        return copied;
     }
 
     private static Dictionary<string, Dictionary<string, List<(string SubtitleNorm, int Index, string DisplayTitle, string DisplaySubtitle)>>> LoadExportIndexes(string exportDir)
@@ -654,13 +821,16 @@ public static class SongSorterCore
 
     private static readonly object BoxDefLock = new();
 
-    private static void EnsureBoxDef(string dir, string title, string genre, string explanation)
+    private static void EnsureBoxDef(string dir, string title, string genre, string explanation, string? bgColor = "#ff0000", string? textColor = "#ffffff")
     {
         var path = Path.Combine(dir, "box.def");
         lock (BoxDefLock)
         {
             Directory.CreateDirectory(dir);
-            File.WriteAllLines(path, new[] { "#TITLE:" + title, "#GENRE:" + genre, "#EXPLANATION:" + explanation, "#BGCOLOR:#ff0000", "#TEXTCOLOR:#ffffff" });
+            var lines = new List<string> { "#TITLE:" + title, "#GENRE:" + genre, "#EXPLANATION:" + explanation };
+            if (!string.IsNullOrEmpty(bgColor)) lines.Add("#BGCOLOR:" + bgColor);
+            if (!string.IsNullOrEmpty(textColor)) lines.Add("#TEXTCOLOR:" + textColor);
+            File.WriteAllLines(path, lines);
         }
     }
 
@@ -804,4 +974,3 @@ public static class SongSorterCore
         return false;
     }
 }
-

--- a/Models/SongModels.cs
+++ b/Models/SongModels.cs
@@ -3,3 +3,18 @@ namespace SongConverter.Models;
 public record SongInfo(string Title, string Subtitle);
 
 public record SongDetail(string Title, string Subtitle, string? FullTitle, string? FolderTitle, string? Wave = null);
+
+/// <summary>
+/// アーケード公式リストに一致しなかった（＝ESE限定の未収録）曲を、
+/// 破棄せず別枠としてカテゴリ単位でソート・出力するための一時保持情報。
+/// 並列走査フェーズで収集し、走査完了後にカテゴリごとへ採番・コピーする。
+/// </summary>
+public sealed record EsePreservedSong(
+    string EseCategory, // AC側カテゴリ名（「02 アニメ」等の表示名）
+    string SongDir,     // コピー元の曲フォルダ
+    string TjaPath,     // 代表となるTJAファイル
+    string? Wave,       // 対応する音声ファイル名（WAVE指定）
+    string Title,       // 表示タイトル
+    string Subtitle,    // 表示サブタイトル
+    string SortKey,     // カテゴリ内ソート用キー（正規化タイトル）
+    string Reason);     // 未収録となった理由（レポート用）

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -22,6 +22,8 @@ public partial class MainForm : Form
     };
 
     private readonly HashSet<string> _selectedSourceCategories = new(SongSorterCore.SourceCategories, StringComparer.OrdinalIgnoreCase);
+    // AC未収録曲を出力するカテゴリ（null = チェックしない＝全無効、全カテゴリ選択なら全出力）
+    private readonly HashSet<string> _selectedEseCategories = new(SongSorterCore.SourceCategories, StringComparer.OrdinalIgnoreCase);
     private Button? _btnCategorySelect;
     private Button? _btnImageSelect;
     private Button? _btnConvertAssetSelect;
@@ -998,40 +1000,89 @@ public partial class MainForm : Form
         {
             Text = LanguageManager.GetString("CategorySelect"),
             StartPosition = FormStartPosition.CenterParent,
-            ClientSize = new Size(360, 380),
+            ClientSize = new Size(400, 430),
             FormBorderStyle = FormBorderStyle.FixedDialog,
             MaximizeBox = false,
             MinimizeBox = false
         };
 
-        var checkedList = new CheckedListBox
+        var tabCtrl = new TabControl
         {
             Dock = DockStyle.Top,
-            Height = 290,
-            CheckOnClick = true
+            Height = 340,
+            Font = new Font("Noto Sans", 9F)
         };
 
         var categoryMap = GetCategoryMap();
-        foreach (var cat in categoryMap)
-        {
-            checkedList.Items.Add(cat.DisplayName, _selectedSourceCategories.Contains(cat.InternalName));
-        }
 
-        var btnAll = new Button { Text = LanguageManager.GetString("All"), Location = new Point(12, 300), Size = new Size(80, 30) };
-        var btnNone = new Button { Text = LanguageManager.GetString("None"), Location = new Point(100, 300), Size = new Size(80, 30) };
-        var btnOk = new Button { Text = LanguageManager.GetString("OK"), Location = new Point(190, 340), Size = new Size(75, 30), DialogResult = DialogResult.OK };
-        var btnCancel = new Button { Text = LanguageManager.GetString("Cancel"), Location = new Point(273, 340), Size = new Size(75, 30), DialogResult = DialogResult.Cancel };
+        // ---- タブ1: 収録曲 ----
+        var tabAc = new TabPage("収録曲（AC公式）");
+        var listAc = new CheckedListBox
+        {
+            Dock = DockStyle.Fill,
+            CheckOnClick = true
+        };
+        foreach (var cat in categoryMap)
+            listAc.Items.Add(cat.DisplayName, _selectedSourceCategories.Contains(cat.InternalName));
+        tabAc.Controls.Add(listAc);
+
+        // ---- タブ2: AC未収録曲 ----
+        var tabEse = new TabPage("AC未収録曲");
+        var listEse = new CheckedListBox
+        {
+            Dock = DockStyle.Fill,
+            CheckOnClick = true
+        };
+        foreach (var cat in categoryMap)
+            listEse.Items.Add(cat.DisplayName, _selectedEseCategories.Contains(cat.InternalName));
+        tabEse.Controls.Add(listEse);
+
+        tabCtrl.TabPages.Add(tabAc);
+        tabCtrl.TabPages.Add(tabEse);
+
+        // ---- 全選択 / 全解除 ボタン ----
+        var btnAll = new Button
+        {
+            Text = LanguageManager.GetString("All"),
+            Location = new Point(12, 350),
+            Size = new Size(80, 30)
+        };
+        var btnNone = new Button
+        {
+            Text = LanguageManager.GetString("None"),
+            Location = new Point(100, 350),
+            Size = new Size(80, 30)
+        };
+
+        CheckedListBox CurrentList() => tabCtrl.SelectedIndex == 0 ? listAc : listEse;
 
         btnAll.Click += (s, e) =>
         {
-            for (var i = 0; i < checkedList.Items.Count; i++) checkedList.SetItemChecked(i, true);
+            var list = CurrentList();
+            for (var i = 0; i < list.Items.Count; i++) list.SetItemChecked(i, true);
         };
         btnNone.Click += (s, e) =>
         {
-            for (var i = 0; i < checkedList.Items.Count; i++) checkedList.SetItemChecked(i, false);
+            var list = CurrentList();
+            for (var i = 0; i < list.Items.Count; i++) list.SetItemChecked(i, false);
         };
 
-        dialog.Controls.Add(checkedList);
+        var btnOk = new Button
+        {
+            Text = LanguageManager.GetString("OK"),
+            Location = new Point(210, 390),
+            Size = new Size(75, 30),
+            DialogResult = DialogResult.OK
+        };
+        var btnCancel = new Button
+        {
+            Text = LanguageManager.GetString("Cancel"),
+            Location = new Point(293, 390),
+            Size = new Size(95, 30),
+            DialogResult = DialogResult.Cancel
+        };
+
+        dialog.Controls.Add(tabCtrl);
         dialog.Controls.Add(btnAll);
         dialog.Controls.Add(btnNone);
         dialog.Controls.Add(btnOk);
@@ -1041,19 +1092,25 @@ public partial class MainForm : Form
 
         if (dialog.ShowDialog(this) != DialogResult.OK) return false;
 
+        // 収録曲カテゴリを更新
         _selectedSourceCategories.Clear();
-        for (int i = 0; i < checkedList.Items.Count; i++)
+        for (int i = 0; i < listAc.Items.Count; i++)
         {
-            if (checkedList.GetItemChecked(i))
-            {
+            if (listAc.GetItemChecked(i))
                 _selectedSourceCategories.Add(categoryMap[i].InternalName);
-            }
         }
-
         if (_selectedSourceCategories.Count == 0)
         {
             foreach (var category in SongSorterCore.SourceCategories)
                 _selectedSourceCategories.Add(category);
+        }
+
+        // AC未収録曲カテゴリを更新
+        _selectedEseCategories.Clear();
+        for (int i = 0; i < listEse.Items.Count; i++)
+        {
+            if (listEse.GetItemChecked(i))
+                _selectedEseCategories.Add(categoryMap[i].InternalName);
         }
 
         return true;
@@ -1064,7 +1121,16 @@ public partial class MainForm : Form
         if (_btnCategorySelect == null) return;
         var total = SongSorterCore.SourceCategories.Length;
         var selected = _selectedSourceCategories.Count == 0 ? total : _selectedSourceCategories.Count;
-        _btnCategorySelect.Text = selected >= total ? LanguageManager.GetString("CategoryAll") : string.Format(LanguageManager.GetString("CategoryCount"), selected, total);
+        var eseSelected = _selectedEseCategories.Count;
+        string baseText = selected >= total
+            ? LanguageManager.GetString("CategoryAll")
+            : string.Format(LanguageManager.GetString("CategoryCount"), selected, total);
+        string eseSuffix = eseSelected == 0
+            ? " / 未収録:なし"
+            : eseSelected >= total
+                ? " / 未収録:全て"
+                : $" / 未収録:{eseSelected}";
+        _btnCategorySelect.Text = baseText + eseSuffix;
     }
 
     private IReadOnlyCollection<string> GetSelectedSourceCategories()
@@ -1159,7 +1225,10 @@ public partial class MainForm : Form
                         runId, 
                         GetSelectedSourceCategories(), 
                         Log, 
-                        ct), ct);
+                        ct,
+                        progressAction: null,
+                        preserveEseSongs: true,
+                        preserveEseCategories: _selectedEseCategories.Count > 0 ? _selectedEseCategories.ToArray() : Array.Empty<string>()), ct);
 
                 Log(result.Summary);
             }
@@ -1570,6 +1639,8 @@ public partial class MainForm : Form
                 DanConvertorIndex = txtDanConvertorIndex.Text,
                 DanMiniPlateText = txtDanMiniPlateText.Text,
                 SelectedCategoriesCsv = string.Join("|", GetSelectedSourceCategories()),
+                EseCategoriesCsv = string.Join("|", _selectedEseCategories),
+                PreserveEseSongs = true, // 旧バージョン互換性のため常にtrue
                 ConvertAssetsJson = JsonSerializer.Serialize(_convertAssetAssignments),
                 // 旧バージョン互換性のため残しておく（空で保存）
                 PlateAssignments = new Dictionary<string, string>(),
@@ -1715,6 +1786,26 @@ public partial class MainForm : Form
                 foreach (var category in SongSorterCore.SourceCategories)
                     _selectedSourceCategories.Add(category);
             }
+
+            // AC未収録曲カテゴリを読み込み（旧設定の PreserveEseSongs も考慮）
+            _selectedEseCategories.Clear();
+            var eseRaw = settings.EseCategoriesCsv ?? string.Empty;
+            if (!string.IsNullOrEmpty(eseRaw))
+            {
+                var eseParts = eseRaw.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                foreach (var part in eseParts)
+                {
+                    if (SongSorterCore.SourceCategories.Contains(part, StringComparer.OrdinalIgnoreCase))
+                        _selectedEseCategories.Add(part);
+                }
+            }
+            else if (settings.PreserveEseSongs)
+            {
+                // 旧バージョン互換：PreserveEseSongs=true なら全カテゴリ有効
+                foreach (var category in SongSorterCore.SourceCategories)
+                    _selectedEseCategories.Add(category);
+            }
+            // PreserveEseSongs=false の旧設定 → _selectedEseCategories は空のまま（全無効）
 
             if (!string.IsNullOrEmpty(settings.ConvertAssetsJson))
             {
@@ -1874,6 +1965,8 @@ public partial class MainForm : Form
         public string DanConvertorIndex { get; set; } = "";
         public string DanMiniPlateText { get; set; } = "";
         public string SelectedCategoriesCsv { get; set; } = "";
+        public string EseCategoriesCsv { get; set; } = string.Join("|", SongSorterCore.SourceCategories); // 全カテゴリデフォルト
+        public bool PreserveEseSongs { get; set; } = true; // 旧バージョン互換性のため残す
         public string ConvertAssetsJson { get; set; } = "";
         public string Language { get; set; } = "";
         // 旧バージョン互換性のため残しておく


### PR DESCRIPTION
1. 処理の追加 (SongSorterCore.cs, SongModels.cs)
   - 全カテゴリの走査完了後、一致しなかった楽曲をカテゴリごとにソート
   - 「99 AC未収録曲」フォルダに各カテゴリのサブフォルダを生成・曲を出力
   - べき等性担保のため、別枠ツリーは毎回まるごと作り直す仕様

2. UIおよび設定の拡張 (MainForm.cs)
   - カテゴリ選択に「AC未収録曲」のタブを追加、個別に選択できるように
   - アプリ終了時・起動時にこれらの選択状態（EseCategoriesCsv）を settings.json へ保存・読込するように （PreserveEseSongs 設定と移行互換）